### PR TITLE
cuda changed to specific device

### DIFF
--- a/chamfer_distance/chamfer_distance.py
+++ b/chamfer_distance/chamfer_distance.py
@@ -12,7 +12,7 @@ cd = load(name="cd",
 
 class ChamferDistanceFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, xyz1, xyz2):
+    def forward(ctx, xyz1, xyz2, device):
         batchsize, n, _ = xyz1.size()
         _, m, _ = xyz2.size()
         xyz1 = xyz1.contiguous()
@@ -26,10 +26,10 @@ class ChamferDistanceFunction(torch.autograd.Function):
         if not xyz1.is_cuda:
             cd.forward(xyz1, xyz2, dist1, dist2, idx1, idx2)
         else:
-            dist1 = dist1.cuda()
-            dist2 = dist2.cuda()
-            idx1 = idx1.cuda()
-            idx2 = idx2.cuda()
+            dist1 = dist1.to(device)
+            dist2 = dist2.to(device)
+            idx1 = idx1.to(device)
+            idx2 = idx2.to(device)
             cd.forward_cuda(xyz1, xyz2, dist1, dist2, idx1, idx2)
 
         ctx.save_for_backward(xyz1, xyz2, idx1, idx2)
@@ -37,7 +37,7 @@ class ChamferDistanceFunction(torch.autograd.Function):
         return dist1, dist2, idx1, idx2
 
     @staticmethod
-    def backward(ctx, graddist1, graddist2):
+    def backward(ctx, graddist1, graddist2, device):
         xyz1, xyz2, idx1, idx2 = ctx.saved_tensors
 
         graddist1 = graddist1.contiguous()
@@ -49,8 +49,8 @@ class ChamferDistanceFunction(torch.autograd.Function):
         if not graddist1.is_cuda:
             cd.backward(xyz1, xyz2, gradxyz1, gradxyz2, graddist1, graddist2, idx1, idx2)
         else:
-            gradxyz1 = gradxyz1.cuda()
-            gradxyz2 = gradxyz2.cuda()
+            gradxyz1 = gradxyz1.to(device)
+            gradxyz2 = gradxyz2.to(device)
             cd.backward_cuda(xyz1, xyz2, gradxyz1, gradxyz2, graddist1, graddist2, idx1, idx2)
 
         return gradxyz1, gradxyz2
@@ -58,4 +58,5 @@ class ChamferDistanceFunction(torch.autograd.Function):
 
 class ChamferDistance(torch.nn.Module):
     def forward(self, xyz1, xyz2):
-        return ChamferDistanceFunction.apply(xyz1, xyz2)
+        assert(xyz1.device == xyz2.device)
+        return ChamferDistanceFunction.apply(xyz1, xyz2, xyz1.device)


### PR DESCRIPTION
I was running into issues while using this function for code that was running on a device other than 'cuda:0'. 

For example: `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:6 and cuda:0!`.

This simple fix resolves the issue. Cheers!